### PR TITLE
Implement reactive voice service skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# ttc
+# TTC Voice Service
+
+This repository provides a skeleton of a reactive Python service that processes
+streaming audio from a telephony provider. The service is designed to
+transcribe the incoming speech using Yandex SpeechKit, search for answers in a
+knowledge base via a Retrieval‑Augmented Generation (RAG) pipeline and return
+synthesized speech responses through Yandex SpeechKit TTS.
+
+## Components
+- `app/main.py` – FastAPI application exposing a `/stream` WebSocket endpoint.
+- `app/asr.py` – placeholder for Yandex SpeechKit ASR integration.
+- `app/tts.py` – placeholder for Yandex SpeechKit TTS integration.
+- `app/rag.py` – placeholder for vector search and local LLM generation.
+
+## Usage
+Run the API with Uvicorn:
+```bash
+uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+Connect to `/stream` via WebSocket and send raw audio frames. For each chunk the
+service should perform the following steps once the TODO sections are
+implemented:
+1. Transcribe the audio with ASR.
+2. Retrieve context and generate an answer using RAG.
+3. Synthesize the answer to speech.
+4. Stream the audio response back to the client.
+
+### Installation
+
+Install dependencies from `requirements.txt` before running the service:
+
+```bash
+pip install -r requirements.txt
+```
+
+The current implementation contains placeholders and requires integration with
+actual Yandex SpeechKit APIs and a knowledge base.

--- a/app/asr.py
+++ b/app/asr.py
@@ -1,0 +1,11 @@
+import aiohttp
+
+async def transcribe_audio_chunk(chunk: bytes, lang: str = "ru-RU") -> str:
+    """Transcribe audio chunk using Yandex SpeechKit ASR.
+
+    This is a placeholder implementation. In production it should send
+    the audio data to the Yandex SpeechKit streaming API and return the
+    recognized text as soon as it is available.
+    """
+    # TODO: implement actual request to Yandex SpeechKit
+    return ""

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI, WebSocket
+
+from .asr import transcribe_audio_chunk
+from .rag import generate_answer
+from .tts import synthesize_text
+
+app = FastAPI(title="Reactive Voice Service")
+
+
+@app.websocket("/stream")
+async def stream_endpoint(websocket: WebSocket, lang: str = "ru-RU"):
+    """Receive audio chunks and respond with synthesized speech.
+
+    The endpoint expects raw audio frames from a telephony provider. For each
+    received chunk it performs ASR, searches for an answer using RAG and then
+    sends synthesized speech back to the client. All heavy lifting should be
+    done in a streaming manner to minimize latency.
+    """
+    await websocket.accept()
+
+    async for chunk in websocket.iter_bytes():
+        text = await transcribe_audio_chunk(chunk, lang=lang)
+        if not text:
+            continue
+        answer = await generate_answer(text)
+        audio = await synthesize_text(answer, lang=lang)
+        if audio:
+            await websocket.send_bytes(audio)

--- a/app/rag.py
+++ b/app/rag.py
@@ -1,0 +1,11 @@
+"""Retrieval-Augmented Generation utilities."""
+
+async def generate_answer(query: str) -> str:
+    """Generate answer from knowledge base using RAG approach.
+
+    This is a placeholder implementation. In production this function should
+    perform vector search over embedded documents and use a local LLM to
+    generate the final response.
+    """
+    # TODO: implement vector search and local LLM generation
+    return ""

--- a/app/tts.py
+++ b/app/tts.py
@@ -1,0 +1,10 @@
+import aiohttp
+
+async def synthesize_text(text: str, lang: str = "ru-RU") -> bytes:
+    """Synthesize speech using Yandex SpeechKit TTS.
+
+    This is a placeholder implementation. In production it should send
+    the text to the Yandex SpeechKit API and stream back audio bytes.
+    """
+    # TODO: implement actual request to Yandex SpeechKit
+    return b""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+aiohttp
+pytest

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,7 @@
+import importlib
+
+MODULES = ["app.main", "app.asr", "app.tts", "app.rag"]
+
+def test_imports():
+    for mod in MODULES:
+        importlib.import_module(mod)


### PR DESCRIPTION
## Summary
- document initial service structure
- create FastAPI app with /stream websocket
- add placeholder modules for ASR, TTS and RAG
- add basic import test
- add requirements list and installation notes

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*